### PR TITLE
reduce python requirement to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache License 2.0"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.10"
 textual = "^0.74.0"
 psutil = "^6.0.0"
 distro = "^1.9.0"


### PR DESCRIPTION
Was there a reason for a minimum python version of 3.11?  I am on ros-humble with python 3.10 and if I install off this branch everything appears to be working?  I've only just started using it so maybe things I'm not aware of are broken. 

