### PR TITLE
Add support for running with docker and docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ros:kilted-ros-core
+
+RUN curl -sSL https://install.python-poetry.org | python3 -
+
+WORKDIR /r2s
+
+COPY pyproject.toml poetry.lock* ./
+
+RUN /root/.local/bin/poetry install --no-root
+
+COPY . .
+
+RUN /root/.local/bin/poetry install
+
+RUN echo "PATH=/root/.local/bin:${PATH}" >> ${HOME}/.bash_aliases \
+    echo "source /opt/ros/kilted/setup.bash" >> ${HOME}/.bash_aliases \
+    echo "alias r2s='cd /r2s && poetry run r2s'" >> ${HOME}/.bash_aliases

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ COPY . .
 
 RUN /root/.local/bin/poetry install
 
-RUN echo "PATH=/root/.local/bin:${PATH}" >> ${HOME}/.bash_aliases \
-    echo "source /opt/ros/kilted/setup.bash" >> ${HOME}/.bash_aliases \
-    echo "alias r2s='cd /r2s && poetry run r2s'" >> ${HOME}/.bash_aliases
+RUN echo "PATH=/root/.local/bin:${PATH}" >> ${HOME}/.bash_aliases 
+RUN echo "source /opt/ros/kilted/setup.bash" >> ${HOME}/.bash_aliases
+RUN echo "alias r2s='cd /r2s && poetry run r2s'" >> ${HOME}/.bash_aliases
+RUN echo "alias dev='\$(poetry env activate) && textual run --dev r2s.main:main'" >> ${HOME}/.bash_aliases
+RUN echo "alias console='\$(poetry env activate) && textual console'" >> ${HOME}/.bash_aliases

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ poetry install
 poetry run r2s
 ```
 
+To run in a docker container:
+
+```
+git clone https://github.com/mjcarroll/r2s.git
+cd r2s
+docker compose run --remove-orphans r2s
+```
+
+
 ## Development
 
 To run in development mode:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ poetry shell
 textual console
 ```
 
+To run in development inside a docker container:
+
+```
+docker compose watch
+```
+
+```
+docker compose exec -it r2s /bin/bash
+console
+```
+
+```
+docker compose exec -it r2s /bin/bash
+dev
+```
 ## Roadmap
 
 Currently, there are 2 primary widgets for visualizing information in a grid or as a stream of text logs.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+services:
+  r2s:
+    build: 
+      context: .
+    network_mode: "host"
+    stdin_open: true   
+    tty: true   
+    command: bash -c "\
+      source /opt/ros/kilted/setup.bash \
+      && cd /r2s \
+      && /root/.local/bin/poetry run r2s"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,3 +9,8 @@ services:
       source /opt/ros/kilted/setup.bash \
       && cd /r2s \
       && /root/.local/bin/poetry run r2s"
+    develop:
+      watch:
+        - action: sync
+          path: ./r2s
+          target: /r2s/r2s


### PR DESCRIPTION
This PR makes it possible to run r2s in a docker container.
This makes it easier for people with conflicting Python or ROS versions.